### PR TITLE
Namespace revision & port to markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img src="https://user-images.githubusercontent.com/5917472/225585663-8054c647-83d7-4b90-abb3-9ec3994ab30f.png" />
 </p>
 
-Interfaces described in this document are prone to change. Anyone can choose freely to ignore these guidelines as they see fit, but it is preferred to follow this standard to make modules / projects as compatible to one another as possible.
+These guidelines are aimed to help people get access to RAS systems and encourage alignment of interfaces between projects/modules. Anyone can choose freely to ignore these guidelines as they see fit, but it is preferred to follow this standard enhance component compatibility.
 
 ## Namespaces 
 The table below shows identifiers are used for our vessels. These names are commonly used when something needs to refer to a specific ship, such as ROS topics. 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ For the Tito Neri the actuation array is defined as
 
 <br>
 For the Tito Neri the telemetry array is defined as:
+
 | Index | Content                   | Unit                                 |
 |-------|---------------------------|--------------------------------------|
 | 0     | dcmotor\_P\_reference     | RPM                                  |

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The table below shows identifiers are used for our vessels. These names are comm
 ## ROS topics & message formats
 To have modules easily swappable and connectable, the following default messagetypes and namespacing are suggested. 'vesselID' refers to the Identifier of a particular vessel as described in the previous section.
 
-Old namespace convention:
+Old namespace convention: (pre 2023)
 | Topicname                                  | Description             | Messagetype        | Default unit(s)                                        |
 |-------------------------------------------|-------------------------|--------------------|--------------------------------------------------------|
 | /vesselID/u_ref  | Reference/desired Actuator state  | std_msgs/Float32MultiArray* | shaft velocities: Rpm       |
@@ -39,7 +39,7 @@ Old namespace convention:
 | /vesselID/heading_ref | Reference/desired yaw | std_msgs/Float32 | radians (clockwise from above w.r.t. north) |
 | /vesselID/telemetry  | microcontroller state / telemetry  | std_msgs/Float32MultiArray* | various  |
 
-Updated namespaces
+Updated namespaces (we will migrate tho this throughout 2023)
 | Topicname                                 | Description             | Messagetype        | Default unit(s)                                        |
 |-------------------------------------------|-------------------------|--------------------|--------------------------------------------------------|
 | /vesselID/reference/actuation  |  Reference/desired Actuator state     | std_msgs/Float32MultiArray* | shaft velocities: Rpm    |

--- a/README.md
+++ b/README.md
@@ -1,4 +1,59 @@
-# Researchlab Autonomous Shipping Delft - internal standards
+# Researchlab Autonomous Shipping Delft - Internal standards
 
-## Communication 
-main.pdf shows the default communication interface with the ships. 
+<p align="center">
+  <img src="https://user-images.githubusercontent.com/5917472/225585663-8054c647-83d7-4b90-abb3-9ec3994ab30f.png" />
+</p>
+
+Interfaces described in this document are prone to change. 
+
+## Namespaces 
+The table below shows identifiers are used for our vessels. These names are commonly used when something needs to refer to a specific ship, such as ROS topics. 
+
+| Model      | Description          | Identifier  |
+|------------|----------------------|-------------|
+| TitoNeri   | Light-blue Tito Neri | RAS\_TN\_LB |
+| TitoNeri   | Dark-blue Tito Neri  | RAS\_TN\_DB |
+| TitoNeri   | Red Tito Neri        | RAS\_TN\_RE |
+| TitoNeri   | Yellow Tito Neri     | RAS\_TN\_YE |
+| TitoNeri   | Purple Tito Neri     | RAS\_TN\_PU |
+| TitoNeri   | Green Tito Neri      | RAS\_TN\_GR |
+| TitoNeri   | Orange Tito Neri     | RAS\_TN\_OR |
+| GreySeabax | The Grey-seabax      | RAS\_GS     |
+| Delfia-1*  | Delfia 1             | RAS\_DF\_1  |
+| Delfia-1*  | Delfia 2             | RAS\_DF\_2  |
+| Delfia-1*  | Delfia 3             | RAS\_DF\_3  |
+| Delfia-1*  | Delfia 4             | RAS\_DF\_4  |
+| Delfia-1*  | Delfia 5             | RAS\_DF\_5  |
+
+## ROS topics & message formats
+To have modules easily swappable and connectable, the following default messagetypes and namespacing are suggested. 'vesselID' refers to the Identifier of a particular vessel as described in the previous section.
+
+Old namespace convention:
+| Topicname                                  | Description             | Messagetype        | Default unit(s)                                        |
+|-------------------------------------------|-------------------------|--------------------|--------------------------------------------------------|
+| /vesselID/u_ref  | Reference/desired Actuator state  | std_msgs/Float32MultiArray* | shaft velocities: Rpm       |
+| /vesselID/u_est | Measured actuator state | std_msgs/Float32MultiArray  | identical to /vesselID/u_ref |
+| OptiRAS/vesselID | Estimated pose          | std_msgs/pose       | meters,quaternions   |
+| /vesselID/geopos_est | Estimated/measured global position | sensor_msgs/NavSatFix      | degrees (latitude, longitude), meters (altitude)   |
+| /vesselID/heading_est | Estimated/measured yaw | std_msgs/Float32 | radians (clockwise from above w.r.t. north) |
+| /vesselID/heading_ref | Reference/desired yaw | std_msgs/Float32 | radians (clockwise from above w.r.t. north) |
+
+Updated namespaces
+| Topicname                                 | Description             | Messagetype        | Default unit(s)                                        |
+|-------------------------------------------|-------------------------|--------------------|--------------------------------------------------------|
+| /vesselID/reference/actuation  |  Reference/desired Actuator state     | std_msgs/Float32MultiArray* | shaft velocities: Rpm    |
+| /vesselID/state/actuation | Measured actuator state | std_msgs/Float32MultiArray  | identical to /vesselID/u_ref |
+| /vesselID/state/poseLocal | Estimated/measured pose w.r.t. local coordinate system    | stdmsgs/pose       | meters,quaternions    |
+| /vesselID/state/posGlobal | Estimated/measured global position | sensor_msgs/NavSatFix      | degrees (latitude, longitude), meters (altitude)   |
+| /vesselID/reference/posGlobal | Reference/desired global position | sensor_msgs/NavSatFix      | degrees (latitude, longitude), meters (altitude)   |
+| /vesselID/state/heading | Estimated/measured yaw | std_msgs/Float32 | radians (clockwise from above w.r.t. north) |
+| /vesselID/reference/heading | Reference/desired yaw | std_msgs/Float32 | radians (clockwise from above w.r.t. north) |
+
+Actuation of the vessels are defined as follows:
+
+
+| Vessel Type                                 | Actuation vector interpretation      | Unit |
+|-------------------------------------------|-------------------------|--------------------|
+| Delfia-1* | $[propvel_{1},propvel\_{2},propangle\_{1},propangle\_{2}]$| $rps,rps,radians, radians$|
+| Tito Neri | $[propvel_{aft,ps},propvel\_{aft,sb},proppower\_{bow},propangle\_{aft,ps},propangle\_{aft,sb}]$ | $[rpm,rpm,normalized,radians,radians]$ |
+| Grey Seabax | $[]$ |  $[]$ |

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img src="https://user-images.githubusercontent.com/5917472/225585663-8054c647-83d7-4b90-abb3-9ec3994ab30f.png" />
 </p>
 
-Interfaces described in this document are prone to change. 
+These interfaces serve as a main guideline to make people/projects/components interact easier. Adhering to them improves reusability, maintainability and structural integration and collaboration, although this is not obligatory.
 
 ## Namespaces 
 The table below shows identifiers are used for our vessels. These names are commonly used when something needs to refer to a specific ship, such as ROS topics. 
@@ -57,3 +57,16 @@ Actuation of the vessels are defined as follows:
 | Delfia-1* | $[propvel_{1},propvel\_{2},propangle\_{1},propangle\_{2}]$| $rps,rps,radians, radians$|
 | Tito Neri | $[propvel_{aft,ps},propvel\_{aft,sb},proppower\_{bow},propangle\_{aft,ps},propangle\_{aft,sb}]$ | $[rpm,rpm,normalized,radians,radians]$ |
 | Grey Seabax | $[]$ |  $[]$ |
+
+
+## Coordinate systems
+### Tiny lab tank
+The coordinate system of the optitrack system on the tiny lab tank is defined as follows:
+<p align="center">
+  <img src="[https://user-images.githubusercontent.com/5917472/225585663-8054c647-83d7-4b90-abb3-9ec3994ab30f.png](https://user-images.githubusercontent.com/5917472/225597128-5e988305-7c49-4249-9398-7e5f920c1047.jpg)" />
+</p>
+Note that Z does not point down (as in line with the marine standard NED definition). If this is desired, coordinate system transformation can be done by the user.
+
+### Small towing tank
+
+### Flume tank

--- a/README.md
+++ b/README.md
@@ -112,6 +112,6 @@ Note that Z does not point down (as in line with the marine standard NED definit
 ### Flume tank
 ![image](https://user-images.githubusercontent.com/5917472/225601576-15fd108c-e240-41bf-ba62-5503a229fb05.png)
 
-Note that Z does not point down (as in line with the marine standard NED definition). If this is desired, coordinate system transformation can be done by the user.
+Arrows the the figure above denote positive values. Note that Z does not point down (as in line with the marine standard NED definition). If this is desired, coordinate system transformation can be done by the user.
 
 ### Small towing tank

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img src="https://user-images.githubusercontent.com/5917472/225585663-8054c647-83d7-4b90-abb3-9ec3994ab30f.png" />
 </p>
 
-These interfaces serve as a main guideline to make people/projects/components interact easier. Adhering to them improves reusability, maintainability and structural integration and collaboration, although this is not obligatory.
+Interfaces described in this document are prone to change. Anyone can choose freely to ignore these guidelines as they see fit, but it is preferred to follow this standard to make modules / projects as compatible to one another as possible.
 
 ## Namespaces 
 The table below shows identifiers are used for our vessels. These names are commonly used when something needs to refer to a specific ship, such as ROS topics. 
@@ -37,6 +37,7 @@ Old namespace convention:
 | /vesselID/geopos_est | Estimated/measured global position | sensor_msgs/NavSatFix      | degrees (latitude, longitude), meters (altitude)   |
 | /vesselID/heading_est | Estimated/measured yaw | std_msgs/Float32 | radians (clockwise from above w.r.t. north) |
 | /vesselID/heading_ref | Reference/desired yaw | std_msgs/Float32 | radians (clockwise from above w.r.t. north) |
+| /vesselID/telemetry  | microcontroller state / telemetry  | std_msgs/Float32MultiArray* | various  |
 
 Updated namespaces
 | Topicname                                 | Description             | Messagetype        | Default unit(s)                                        |
@@ -49,24 +50,67 @@ Updated namespaces
 | /vesselID/state/heading | Estimated/measured yaw | std_msgs/Float32 | radians (clockwise from above w.r.t. north) |
 | /vesselID/reference/heading | Reference/desired yaw | std_msgs/Float32 | radians (clockwise from above w.r.t. north) |
 
-Actuation of the vessels are defined as follows:
+### Details on particular topics
+Delfia-1* actuation array is as follows:
+| Index | Content                  | Unit    |
+|-------|--------------------------|---------|
+| 0     | Rear propeller velocity  | RPS     |
+| 1     | Front propeller velocity | RPS     |
+| 2     | Angle rear azimuth       | Radians |
+| 3     | Angle front azimuth      | Radians |
+<br>
 
+For the Tito Neri the actuation array is defined as 
 
-| Vessel Type                                 | Actuation vector interpretation      | Unit |
-|-------------------------------------------|-------------------------|--------------------|
-| Delfia-1* | $[propvel_{1},propvel\_{2},propangle\_{1},propangle\_{2}]$| $rps,rps,radians, radians$|
-| Tito Neri | $[propvel_{aft,ps},propvel\_{aft,sb},proppower\_{bow},propangle\_{aft,ps},propangle\_{aft,sb}]$ | $[rpm,rpm,normalized,radians,radians]$ |
-| Grey Seabax | $[]$ |  $[]$ |
+| Index | Content                              | Unit                             |
+|-------|--------------------------------------|----------------------------------|
+| 0     | Aft portside propeller velocity      | RPM                              |
+| 1     | Aft starboardside propeller velocity | RPM                              |
+| 2     | Bow thruster velocity                | Normalized between -1.0 and +1.0 |
+| 3     | Aft portside azimuth angle           | Radians                          |
+| 4     | Aft portside azimuth angle           | Radians                          |
 
+<br>
+For the Tito Neri the telemetry array is defined as:
+| Index | Content                   | Unit                                 |
+|-------|---------------------------|--------------------------------------|
+| 0     | dcmotor\_P\_reference     | RPM                                  |
+| 1     | dcmotor\_SB\_reference    | RPM                                  |
+| 2     | output\_BOW               | float, normalized on range -1.0:1.0) |
+| 3     | reference\_Angle\_P       | deg                                  |
+| 4     | reference\_Angle\_SB      | deg                                  |
+| 5     | dcmotor\_P\_estimated     | RPM                                  |
+| 6     | dcmotor\_SB\_estimated    | RPM                                  |
+| 7     | dcmotorPID\_P\_Output     | normalized on 8 bit reslution 0-255  |
+| 8     | dcmotorPID\_SB\_Output    | normalized on 8 bit reslution 0-255  |
+| 9    | arduinoInternalClock      | ms                                   |
+| 10    | IMU\_accell\_x            | m/s/s                                |
+| 11    | IMU\_accell\_y            | m/s/s                                |
+| 12    | IMU\_accell\_z            | m/s/s                                |
+| 13    | IMU\_gyro\_x              | rad/s                                |
+| 14    | IMU\_gyro\_y              | rad/s                                |
+| 15    | IMU\_gyro\_z              | rad/s                                |
+| 16    | IMU\_magneto\_x           | uT                                   |
+| 17    | IMU\_magneto\_y           | uT                                   |
+| 18    | IMU\_magneto\_z           | uT                                   |
+| 19    | motor\_ESC\_SignalOut\_P  | 1200-1800Hz                          |
+| 20    | motor\_ESC\_SignalOut\_SB | 1200-1800Hz                          |
 
 ## Coordinate systems
+Various basins are equipped with systems that can find and stream state of rigid bodies, such as the Optitrack systems. This section explains in what coordinate system you can expect data to be streamed on ROS with our default system. 
+
 ### Tiny lab tank
 The coordinate system of the optitrack system on the tiny lab tank is defined as follows:
+
 <p align="center">
-  <img src="[https://user-images.githubusercontent.com/5917472/225585663-8054c647-83d7-4b90-abb3-9ec3994ab30f.png](https://user-images.githubusercontent.com/5917472/225597128-5e988305-7c49-4249-9398-7e5f920c1047.jpg)" />
+  <img src="https://user-images.githubusercontent.com/5917472/225598107-5fb8690f-e711-4db0-9817-42325f938185.jpg" />
 </p>
+
+Note that Z does not point down (as in line with the marine standard NED definition). If this is desired, coordinate system transformation can be done by the user.
+
+### Flume tank
+![image](https://user-images.githubusercontent.com/5917472/225601576-15fd108c-e240-41bf-ba62-5503a229fb05.png)
+
 Note that Z does not point down (as in line with the marine standard NED definition). If this is desired, coordinate system transformation can be done by the user.
 
 ### Small towing tank
-
-### Flume tank


### PR DESCRIPTION
- Namespaces have been revised as discussed in the RAS IT Framework meeting between @VGarofano-TUD @rootes1725 @bartboogmans @ccromjongh . 
- The documentation of the standards has been ported to markdown in this repo's readme, as this is equally/more accessible and easier to update than a latex fileformat. 


